### PR TITLE
DM-32353: Configure operator's cluster and namespace with env vars

### DIFF
--- a/strimziregistryoperator/state.py
+++ b/strimziregistryoperator/state.py
@@ -1,17 +1,13 @@
 """Constructed (cached) state as module-level attributes.
 """
 
-cluster_name = 'events'
-"""The name of the Kafka cluster serviced by the operator.
+import os
 
-TODO: make this configurable.
-"""
+cluster_name = os.environ.get('SSR_CLUSTER_NAME', 'events')
+"""The name of the Kafka cluster serviced by the operator. """
 
-namespace = 'events'
-"""The name of the Kubernetes namespace monitored by this operator.
-
-TODO: make this configurable.
-"""
+namespace = os.environ.get('SSR_NAMESPACE', 'events')
+"""The name of the Kubernetes namespace monitored by this operator. """
 
 
 registry_names = set()


### PR DESCRIPTION
Fixes #2, I think.

I have never touched operators so I don't reeeeeally know whether this is the right way to do things, but I think it might work.