### PR TITLE
Permit setting the kopf namespace to watch via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ RUN pip install strimzi-registry-operator-$VERSION.tar.gz && \
 
 USER app
 
-# TODO: refactor "namespace" argument into an environment variable for
-# configurability.
-CMD ["kopf", "run", "--standalone", "-m", "strimziregistryoperator.handlers", "--namespace", "events", "--verbose"]
+# Accept the SSR_NAMESPACE env var for a namespace to watch, defaulting to 'events'.
+CMD ["sh", "-c", "kopf run --standalone -m strimziregistryoperator.handlers --namespace ${SSR_NAMESPACE:-events} --verbose"]


### PR DESCRIPTION
Okay, one last spot where we need an additional option for setting what to watch.

I'm able to override `CMD` in my chart, so this isn't strictly necessary, but it's nice.

This fix is actually somewhat confused, really, since there are really multiple namespaces we care about. There's
 - The namespace to watch for new `strimzischemaregistry` resources.
 - The namespace to query when looking up `Kafka` and `KafkaUser` resources, as well as the `Secret`s associated with them, all created by the Strimzi controller.
 - The namespace to watch for updates to secrets.

Everything in the current code assumes these 3 will all be the same namespace, which isn't necessarily the case, but I don't really want to refactor to support extra complexity since I don't see us needing it immediately.