### PR TITLE
Fix misnamed parameter when refreshing cluster CA cert

### DIFF
--- a/strimziregistryoperator/handlers/secretwatcher.py
+++ b/strimziregistryoperator/handlers/secretwatcher.py
@@ -34,7 +34,7 @@ def handle_secret_change(spec, meta, namespace, name, uid, event, body, logger,
     if name == f'{state.cluster_name}-cluster-ca-cert':
         # Handle a change in the cluster CA certificate
         refresh_with_new_cluster_ca(
-            cluster_ca_body=body,
+            cluster_ca_secret=body,
             namespace=namespace,
             logger=logger)
     elif name in state.registry_names:


### PR DESCRIPTION
Little bug when a cluster's CA cert changes, noticed this in a log line - the parameter is `cluster_ca_secret`, not `cluster_ca_body` : https://github.com/lsst-sqre/strimzi-registry-operator/blob/02a7caeaf89bdf2e2ff159ae6b4068a8c88e3aa1/strimziregistryoperator/handlers/secretwatcher.py#L50