### PR TITLE
Customize listener

### DIFF
--- a/manifests/manifest.yaml
+++ b/manifests/manifest.yaml
@@ -3,19 +3,41 @@ kind: CustomResourceDefinition
 metadata:
   name: strimzischemaregistries.roundtable.lsst.codes
 spec:
+  scope: Namespaced
   group: roundtable.lsst.codes
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: >-
+            StrimziSchemaRegistry represents a desired Schema Registry instance
+          type: object
+          properties:
+            spec:
+              type: object
+              description: >-
+                The specification of the Schema Registry instance.
+              properties:
+                strimzi-version:
+                  type: string
+                  default: "v1beta2"
+                  description: >-
+                    The version of the Strimzi Custom Resource API to use. The
+                    correct value depends on the deployed version of Strimzi.
+                listener:
+                  type: string
+                  default: "internal"
+                  description: >-
+                    The name of the Kafka listener to use to connect.
   names:
     kind: StrimziSchemaRegistry
     plural: strimzischemaregistries
-    shortNames:
-    - ssrs
-    - ssr
     singular: strimzischemaregistry
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
+    shortNames:
+      - ssrs
+      - ssr
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/registry-crd.yaml
+++ b/manifests/registry-crd.yaml
@@ -9,6 +9,28 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          description: >-
+            StrimziSchemaRegistry represents a desired Schema Registry instance
+          type: object
+          properties:
+            spec:
+              type: object
+              description: >-
+                The specification of the Schema Registry instance.
+              properties:
+                strimzi-version:
+                  type: string
+                  default: "v1beta2"
+                  description: >-
+                    The version of the Strimzi Custom Resource API to use. The
+                    correct value depends on the deployed version of Strimzi.
+                listener:
+                  type: string
+                  default: "internal"
+                  description: >-
+                    The name of the Kafka listener to use to connect.
   names:
     kind: StrimziSchemaRegistry
     plural: strimzischemaregistries

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
 # Test dependencies
 tests_require = [
     'pytest==5.2.1',
+    'flake8<4',
     'pytest-flake8>=1.0.6',
 ]
 tests_require += install_requires

--- a/strimziregistryoperator/deployments.py
+++ b/strimziregistryoperator/deployments.py
@@ -36,8 +36,10 @@ def get_cluster_listener(kafka, listener_name="tls"):
             continue
 
     all_names = [listener.get('type') for listener in listeners]
-    msg = f'Could not find address of a listener named {listener_name} from the Kafka resource.'
-    msg += f'Available names: {all_names}'
+    msg = (
+        f'Could not find address of a listener named {listener_name} '
+        f'from the Kafka resource. Available names: {all_names}'
+    )
     raise kopf.TemporaryError(msg, delay=10)
 
 

--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -5,7 +5,7 @@ import kopf
 
 from ..k8s import create_k8sclient, get_deployment, get_service, get_secret
 from ..certprocessor import create_secret
-from ..deployments import (get_cluster_tls_listener, create_deployment,
+from ..deployments import (get_cluster_listener, create_deployment,
                            create_service)
 from .. import state
 
@@ -34,6 +34,7 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
     cluster_name = kafkauser['metadata']['labels']['strimzi.io/cluster']
 
     # Pull the Kafka resource so we can get the listener
+    listener_name = spec.get("listener", "internal")
     kafka = k8s_cr_api.get_namespaced_custom_object(
         group='kafka.strimzi.io',
         version=strimzi_version,
@@ -42,7 +43,7 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
         name=cluster_name
     )
 
-    bootstrap_server = get_cluster_tls_listener(kafka)
+    bootstrap_server = get_cluster_listener(kafka, listener_name)
 
     # Create the JKS-formatted truststore/keystore secrets
     secret = create_secret(

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,13 +1,14 @@
 """Tests for the strimziregistryoperator.deployments module.
 """
 
+import kopf
+import pytest
 import yaml
 
-from strimziregistryoperator.deployments import (
-    get_cluster_tls_listener)
+from strimziregistryoperator.deployments import get_cluster_listener
 
 
-def test_get_cluster_tls_listener():
+def test_get_cluster_listener():
     manifest = (
         'status:\n'
         '  conditions:\n'
@@ -23,5 +24,52 @@ def test_get_cluster_tls_listener():
     )
     kafka = yaml.safe_load(manifest)
 
-    listener = get_cluster_tls_listener(kafka)
+    # Get listener without name - should default to 'tls'
+    listener = get_cluster_listener(kafka)
     assert listener == 'events-kafka-bootstrap.events.svc:9093'
+
+    listener = get_cluster_listener(kafka, "tls")
+    assert listener == 'events-kafka-bootstrap.events.svc:9093'
+
+
+def test_get_cluster_listener_bootstrap():
+    manifest = r"""
+status:
+  clusterId: Ob95JyXzTlecnvjKVx3E2A
+  conditions:
+  - lastTransitionTime: "2021-10-29T18:57:10.607Z"
+    status: "True"
+    type: Ready
+  listeners:
+  - addresses:
+    - host: alert-broker-kafka-bootstrap.strimzi.svc
+      port: 9092
+    bootstrapServers: alert-broker-kafka-bootstrap.strimzi.svc:9092
+    certificates:
+    - |
+      -----BEGIN CERTIFICATE-----
+      redacted
+      -----END CERTIFICATE-----
+    type: internal
+  - addresses:
+    - host: 10.106.209.159
+      port: 9094
+    bootstrapServers: 10.106.209.159:9094
+    certificates:
+    - |
+      -----BEGIN CERTIFICATE-----
+      redacted
+      -----END CERTIFICATE-----
+    type: external
+  observedGeneration: 1
+"""
+    kafka = yaml.safe_load(manifest)
+
+    listener = get_cluster_listener(kafka, "internal")
+    assert listener == 'alert-broker-kafka-bootstrap.strimzi.svc:9092'
+
+    listener = get_cluster_listener(kafka, "external")
+    assert listener == '10.106.209.159:9094'
+
+    with pytest.raises(kopf.TemporaryError):
+        get_cluster_listener(kafka, "missing")


### PR DESCRIPTION
This is the v2 of #10.

It turns out that `type` _is_ the right field to use when pulling from the `status` of a Kafka resource in Strimzi. I was confused because I was looking at pulling it from the `spec` of a Kafka resource. For historical reasons, `type` is used to denote the _name_ of the listener in the status of a Kafka custom resource.

So, the existing code was totally valid - it just only works if the internal listener is named `tls`. This change makes that configurable.

Along the way, I fixed the pytest-flake8 CI bug, and updated the CRD to include a spec.