### PR TITLE
DM-24762: Document Helm and operator settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,6 @@ Overview:
 - Works with Strimzi's TLS authentication and authorization by converting the TLS certificate associated with a KafkaUser into a JKS-formatted keystore and truststore that's used by Confluence Schema Registry.
 - When Strimzi updates either the Kafka cluster's CA certificate or the KafkaUser's client certificates, the operator automatically recreates the JKS truststore/keystore secrets and triggers a rolling restart of the Schema Registry pods.
 
-**This operator is still in early development and testing.
-It probably isn't suitable for use outside LSST at the moment.**
-
 Deploy the operator
 ===================
 


### PR DESCRIPTION
- Add documentation for the Helm chart in addition to the Kustomize method
- Document the `SSR_CLUSTER_NAME` and `SSR_NAMESPACE` environment variables for the operator.
- Document settings on the CRD

Fixes #31 