### PR TITLE
DM-35597: Improve handling of both v1beta1 and v1beta2 Strimzi APIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,5 +168,104 @@ The strimzi-schema-registry operator deploys the Schema Registry given a ``Strim
 
 - ``strimzi-version`` is the version of the ``kafka.strimzi.io`` Custom Resource API to use.
   The correct value depends on the deployed version of Strimzi.
-- ``listener`` is the Kafka listener that the Schema Registry should use.
-  Available values: ``plain``, ``tls`` and ``external``.
+  The current Strimzi API  version is ``v1beta2``.
+  Strimzi versions 0.21.0 and earlier support the ``v1beta1`` API.
+
+- ``listener`` is the :ref:`name <listener-config>` of the Kafka listener that the Schema Registry should use.
+  The default value is ``tls``, but you should set this value based on your ``Kafka`` resource.
+
+.. _listener-config:
+
+The listener configuration
+""""""""""""""""""""""""""
+
+The ``spec.listener`` field in the ``StrimziSchemaRegistry`` resource specifies the Kafka broker listener that the Schema Registry uses.
+These listeners are configured in the ``Kafka`` resource you created with Strimzi.
+
+For example, consider a ``Kafka`` resource:
+
+.. code-block:: yaml
+
+   apiVersion: kafka.strimzi.io/v1beta2
+   kind: Kafka
+   metadata:
+     name: my-cluster
+   spec:
+     kafka:
+       #...
+       listeners:
+         - name: plain
+           port: 9092
+           type: internal
+           tls: false
+         - name: tls
+           port: 9093
+           type: internal
+           tls: true
+           authentication:
+             type: tls
+         - name: external1
+           port: 9094
+           type: route
+           tls: true
+         - name: external2
+           port: 9095
+           type: ingress
+           tls: true
+           authentication:
+             type: tls
+           configuration:
+             bootstrap:
+               host: bootstrap.myingress.com
+             brokers:
+             - broker: 0
+               host: broker-0.myingress.com
+             - broker: 1
+               host: broker-1.myingress.com
+             - broker: 2
+               host: broker-2.myingress.com
+       #...
+
+To use the encrypted internal listener, the ``spec.listener`` field in your ``StrimziSchemaRegistry`` resource should be ``tls``:
+
+.. code-block:: yaml
+
+   apiVersion: roundtable.lsst.codes/v1beta1
+   kind: StrimziSchemaRegistry
+   metadata:
+     name: confluent-schema-registry
+   spec:
+     listener: tls
+
+To use the unencrypted internal listener instead, the ``spec.listener`` field in your ``StrimziSchemaRegistry`` resource should be ``plain`` instead:
+
+.. code-block:: yaml
+
+   apiVersion: roundtable.lsst.codes/v1beta1
+   kind: StrimziSchemaRegistry
+   metadata:
+     name: confluent-schema-registry
+   spec:
+     listener: plain
+
+Strimzi ``v1beta1`` listener configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In older versions of Strimzi with the ``v1beta1`` API, listeners were not named.
+Instead, three types of listeners were available:
+
+.. code-block:: yaml
+
+   apiVersion: kafka.strimzi.io/v1beta1
+   kind: Kafka
+   spec:
+     kafka:
+       # ...
+       listeners:
+         plain: {}
+         tls:
+           authentication:
+             type: "tls"
+         external: {}
+
+In this case, set the ``spec.listener`` field in your ``StrimziSchemaRegistry`` to either ``plain``, ``tls``, or ``external``.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 strimzi-registry-operator
 #########################
 
-A Kubernetes Operator for running the `Confluent Schema Registry <https://docs.confluent.io/current/schema-registry/index.html>`_ in a `Strimzi <https://strimzi.io>`_-based `Kafka <https://kafka.apache.org/>`_ cluster that's secured with TLS.
+A Kubernetes Operator for running the `Confluent Schema Registry <https://docs.confluent.io/current/schema-registry/index.html>`_ in a `Strimzi <https://strimzi.io>`_-based `Kafka <https://kafka.apache.org/>`_ cluster that's optionally secured with TLS.
 
 Overview:
 
@@ -21,7 +21,7 @@ Two operator deployment options are available: `Helm <https://helm.sh>`__ and `K
 With Helm
 ---------
 
-A Helm chart is available for strimzi-registry-operator on GitHub at `lsst-sqre/charts <https://github.com/lsst-sqre/charts/tree/master/charts/strimzi-registry-operator>`__.
+A Helm chart is available for strimzi-registry-operator on GitHub at `lsst-sqre/charts <https://github.com/lsst-sqre/charts/tree/master/charts/strimzi-registry-operator>`_.
 
 .. code-block:: sh
 

--- a/strimziregistryoperator/deployments.py
+++ b/strimziregistryoperator/deployments.py
@@ -1,13 +1,30 @@
-"""Utilities for creating deployments and related resources.
-"""
+"""Utilities for creating deployments and related resources."""
 
-__all__ = ("get_cluster_listener", "create_deployment", "create_service")
+__all__ = ["get_kafka_bootstrap_server", "create_deployment", "create_service"]
 
 import kopf
 
 
-def get_cluster_listener(kafka, listener_name="tls"):
-    """Get a listener by name from a Kafka cluster deployment."""
+def get_kafka_bootstrap_server(kafka, *, listener_name):
+    """Get the bootstrap server for a Strimzi Kafka cluster corresponding
+    to the named listener using information from the ``status.listeners``
+    field.
+
+    Parameters
+    ----------
+    kafkak : dict
+        The Kafka resource.
+    listener_name : str
+        The name of the listener. In Strimzi `v1beta2`, this is
+        `spec.listeners[].name`. In Strimzi `v1beta1`, this is
+        `spec.listeners.[tls|plain|external]`.
+
+    Returns
+    -------
+    server : str
+        The bootstrap server connection info (``host:port``) for the given
+        Kafka listener.
+    """
     try:
         listeners = kafka["status"]["listeners"]
     except KeyError:

--- a/strimziregistryoperator/deployments.py
+++ b/strimziregistryoperator/deployments.py
@@ -2,17 +2,19 @@
 
 __all__ = ["get_kafka_bootstrap_server", "create_deployment", "create_service"]
 
+from typing import Mapping
+
 import kopf
 
 
 def get_kafka_bootstrap_server(kafka, *, listener_name):
-    """Get the bootstrap server for a Strimzi Kafka cluster corresponding
-    to the named listener using information from the ``status.listeners``
-    field.
+    """Get the bootstrap server address for a Strimzi Kafka cluster
+    corresponding to the named listener using information from the
+    ``status.listeners`` field.
 
     Parameters
     ----------
-    kafkak : dict
+    kafka : dict
         The Kafka resource.
     listener_name : str
         The name of the listener. In Strimzi `v1beta2`, this is
@@ -25,6 +27,28 @@ def get_kafka_bootstrap_server(kafka, *, listener_name):
         The bootstrap server connection info (``host:port``) for the given
         Kafka listener.
     """
+    # Handle the legacy code path in a separate function
+    if kafka["apiVersion"] == "kafka.strimzi.io/v1beta1":
+        return _get_v1beta1_bootstrap_server(
+            kafka, listener_type=listener_name
+        )
+
+    # This assumes kafka.strimzi.io/v1beta2 or later
+
+    # As a fallback for some strimzi v1beta2 representations of
+    # status.listeners, the status.listeners[].name field might be missing
+    # so we need to use the status.listeners[].type field instead. First
+    # look up the type corresponding the the named listener.
+    listener_types = {
+        listener["name"]: listener["type"]
+        for listener in kafka["spec"]["kafka"]["listeners"]
+    }
+    if listener_name not in listener_types:
+        raise kopf.TemporaryError(
+            f"Listener named {listener_name} is not known. Available "
+            f"listeners are {', '.join(listener_types.keys())}"
+        )
+
     try:
         listeners = kafka["status"]["listeners"]
     except KeyError:
@@ -35,28 +59,66 @@ def get_kafka_bootstrap_server(kafka, *, listener_name):
 
     for listener in listeners:
         try:
-            # For various historical reasons, the 'name' of the listener is
-            # called 'type' in the status field of a Kafka resource from
-            # Strimzi.
-            if listener["type"] == listener_name:
-                # Convenience field available in some versions of Strimzi.
-                if "bootstrapServers" in listener:
-                    return listener["bootstrapServers"]
+            # Current v1beta2 strimzi specs include a
+            # status.listeners[].name field
+            if "name" in listener and listener["name"] == listener_name:
+                return _format_server_address(listener)
 
-                # fall back to constructing it ourselves from the first address
-                # on the listener, which should usually work.
-                else:
-                    address = listener["addresses"][0]
-                    return f'{address["host"]}:{address["port"]}'
+            # Otherwise use the easlier mapping of listener types to types
+            # for the case when only status.listeners[].type is available.
+            # There's potential degeneracy, but what can we do?
+            elif listener["type"] == listener_types[listener_name]:
+                return _format_server_address(listener)
+
         except (KeyError, IndexError):
             continue
 
     all_names = [listener.get("type") for listener in listeners]
     msg = (
         f"Could not find address of a listener named {listener_name} "
-        f"from the Kafka resource. Available names: {all_names}"
+        f"from the Kafka resource. Available names: {', '.join(all_names)}"
     )
-    raise kopf.TemporaryError(msg, delay=10)
+    raise kopf.Error(msg, delay=10)
+
+
+def _format_server_address(listener_status: dict) -> str:
+    # newer versions of Strimzi provide a status.listeners[].bootstrapServers
+    # field, but we can compute that from
+    # status.listeners[].addresses[0] as a fallback
+    if "bootstrapServers" in listener_status.keys():
+        return listener_status["bootstrapServers"]
+    else:
+        address = listener_status["addresses"][0]
+        return f'{address["host"]}:{address["port"]}'
+
+
+def _get_v1beta1_bootstrap_server(
+    kafka: Mapping, *, listener_type: str
+) -> str:
+    try:
+        listeners_status = kafka["status"]["listeners"]
+    except KeyError:
+        raise kopf.TemporaryError(
+            "Could not get status.listeners from Kafka resource.",
+            delay=10,
+        )
+
+    for listener_status in listeners_status:
+        try:
+            if listener_status["type"] == listener_type:
+                # build boostrap server connection info
+                return _format_server_address(listener_status)
+        except (KeyError, IndexError):
+            continue
+
+    all_listener_types = [
+        listener.get("type", "UNKNOWN") for listener in listeners_status
+    ]
+    raise kopf.TemporaryError(
+        f"Could not find address of a {listener_type} listener"
+        f"from the Kafka resource. Available types: {all_listener_types}",
+        delay=10,
+    )
 
 
 def create_deployment(*, name, bootstrap_server, secret_name, secret_version):

--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -35,29 +35,60 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
     logger
         The kopf logger.
     """
-    logger.info(f'Creating a new registry deployment: "{name}"')
 
     k8s_client = create_k8sclient()
     k8s_apps_v1_api = k8s_client.AppsV1Api()
     k8s_cr_api = k8s_client.CustomObjectsApi()
     k8s_core_v1_api = k8s_client.CoreV1Api()
 
-    strimzi_version = spec.get("strimzi-version", "v1beta2")
-    # Pull the KafkaUser resource so we can get the cluster name
+    # Get configurations from StrimziSchemaRegistry
+    try:
+        strimzi_api_version = spec["strimzi-version"]
+    except KeyError:
+        strimzi_api_version = "v1beta2"
+        logger.warning(
+            "StrimziSchemaRegistry %s is missing a strimzi-version, "
+            "using default %s",
+            name,
+            strimzi_api_version,
+        )
+
+    try:
+        listener_name = spec["listener"]
+    except KeyError:
+        listener_name = "tls"
+        logger.warning(
+            "StrimziSchemaRegistry %s is missing a listener name, "
+            "using default %s",
+            name,
+            listener_name,
+        )
+
+    logger.info(
+        "Creating a new Schema Registry deployment: %s with listener=%s and "
+        "strimzi-version=%s",
+        name,
+        listener_name,
+        strimzi_api_version,
+    )
+
+    # Get the name of the Kafka cluster associated with the
+    # StrimziSchemaRegistry's associated strimzi KafkaUser resource.
+    # The StrimziSchemaRegistry and its KafkaUser have the same name.
     kafkauser = k8s_cr_api.get_namespaced_custom_object(
         group="kafka.strimzi.io",
-        version=strimzi_version,
+        version=strimzi_api_version,
         namespace=namespace,
         plural="kafkausers",
         name=name,  # assume StrimziSchemaRegistry name matches
     )
     cluster_name = kafkauser["metadata"]["labels"]["strimzi.io/cluster"]
 
-    # Pull the Kafka resource so we can get the listener
-    listener_name = spec.get("listener", "tls")
+    # Get the Kafka bootstrap server corresponding to the configured
+    # Kafka listener name.
     kafka = k8s_cr_api.get_namespaced_custom_object(
         group="kafka.strimzi.io",
-        version=strimzi_version,
+        version=strimzi_api_version,
         namespace=namespace,
         plural="kafkas",
         name=cluster_name,

--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -7,7 +7,7 @@ from ..certprocessor import create_secret
 from ..deployments import (
     create_deployment,
     create_service,
-    get_cluster_listener,
+    get_kafka_bootstrap_server,
 )
 from ..k8s import create_k8sclient, get_deployment, get_secret, get_service
 
@@ -62,8 +62,9 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
         plural="kafkas",
         name=cluster_name,
     )
-
-    bootstrap_server = get_cluster_listener(kafka, listener_name)
+    bootstrap_server = get_kafka_bootstrap_server(
+        kafka, listener_name=listener_name
+    )
 
     # Create the JKS-formatted truststore/keystore secrets
     secret = create_secret(

--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -1,5 +1,4 @@
-"""Kopf handler for the creation of a StrimziSchemaRegistry.
-"""
+"""Kopf handler for the creation of a StrimziSchemaRegistry."""
 
 import kopf
 
@@ -17,6 +16,24 @@ from ..k8s import create_k8sclient, get_deployment, get_secret, get_service
 def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
     """Handle creation of a StrimziSchemaRegistry resource by deploying a
     new Schema Registry.
+
+    Parameters
+    ----------
+    spec : dict
+        The ``spec`` field of the ``StrimziSchemaRegistry`` custom Kubernetes
+        resource.
+    meta : dict
+        The ``metadata`` field of the ``StrimziSchemaRegistry`` custom
+        Kubernetes resource.
+    namespace : str
+        The Kubernetes namespace of the ``StrimziSchemaRegistry`` custom
+        Kubernetes resource.
+    uid : str
+        The ``metadata.uid`` field of ``StrimziSchemaRegistry``.
+    body : dict
+        The full body of the ``StrimziSchemaRegistry`` as a read-only dict.
+    logger
+        The kopf logger.
     """
     logger.info(f'Creating a new registry deployment: "{name}"')
 


### PR DESCRIPTION
This PR attempts to clarify the listener *type* and *name* terminology, and indicate to the user that we're interested in listener names for the modern Strimzi usage.

## How the Strimzi listener specification has changed

In old versions of Strimzi, [three types of listeners](https://strimzi.io/docs/0.14.0/#con-kafka-listeners-deployment-configuration-kafka) were available: `plain`, `tls`, and `external`.

```yaml
apiVersion: kafka.strimzi.io/v1beta1
kind: Kafka
spec:
  kafka:
    # ...
    listeners:
      plain: {}
      tls:
        authentication:
          type: "tls"
      external: {}
```

strimzi-registry-operator uses the `status.listeners` field on the `Kafka` resource to resolve the bootstrap server. In older versions of Strimzi, this looked like:

```yaml
apiVersion: kafka.strimzi.io/v1beta1
kind: Kafka
status:
  listeners:
    - addresses:
      - host events-kafka-bootstrap.events.svc
        port: 9093
    type: tls
```

Again, all listeners had *types* in the original `v1beta1` Strimzi API.

When the Strimzi `v1beta2` API came out, the [listener schema changed significantly.](https://strimzi.io/docs/operators/latest/configuring.html#type-GenericKafkaListener-reference) Now `spec.kafka.listeners` became an array type, and you could name a listener, in addition to giving it a type. An example from the Strimzi 0.29.0 docs:

```yaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
metadata:
  name: my-cluster
spec:
  kafka:
    #...
    listeners:
      - name: plain
        port: 9092
        type: internal
        tls: false
      - name: tls
        port: 9093
        type: internal
        tls: true
        authentication:
          type: tls
      - name: external1
        port: 9094
        type: route
        tls: true
      - name: external2
        port: 9095
        type: ingress
        tls: true
        authentication:
          type: tls
        configuration:
          bootstrap:
            host: bootstrap.myingress.com
          brokers:
          - broker: 0
            host: broker-0.myingress.com
          - broker: 1
            host: broker-1.myingress.com
          - broker: 2
            host: broker-2.myingress.com
    #...
```

So whereas a listeners `type` (tls, plain, or external) was what we expected a StrimziSchemaRegistry operator user to configure in Strimzi v1beta1, in v1beta2 we expect the user to configure the listener's `name`.

To make things slightly confusing, in v1beta2, `type` came to be used for a slightly different purpose. Types can be `internal`, `route`, `loadbalancer`, `nodeport`, or `ingress`. There's no longer a `plain` or `tls` type because those are authentication details configured separately.

Further, in initial versions of Strimzi using the `v1beta2` API, the `status.listeners` field now listed listeners and only their `type`, but not their `name`:

```
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
status:
  listeners:
  - addresses:
    - host: alert-broker-kafka-bootstrap.strimzi.svc
      port: 9092
    bootstrapServers: alert-broker-kafka-bootstrap.strimzi.svc:9092
    certificates:
    - "..."
    type: internal
  - addresses:
    - host: 10.106.209.159
      port: 9094
    bootstrapServers: 10.106.209.159:9094
    certificates:
    - "..."
    type: external
```

To deal with this listener information, Strimzi Registry Operator needs to look at `spec.listeners` and find the type associated with the named listener.

More recently, Strimzi has started to include the listener name in `status.listeners`, which is ideal:

```yaml
apiVersion: kafka.strimzi.io/v1beta2
kind: Kafka
status:
  listeners:
    - addresses:
        - host: sasquatch-kafka-bootstrap.sasquatch.svc
          port: 9092
      bootstrapServers: 'sasquatch-kafka-bootstrap.sasquatch.svc:9092'
      name: plain
      type: plain
    - addresses:
        - host: sasquatch-kafka-bootstrap.sasquatch.svc
          port: 9093
      bootstrapServers: 'sasquatch-kafka-bootstrap.sasquatch.svc:9093'
      certificates:
        - ""
      name: tls
      type: tls
```