### PR TITLE
DM-35597: Use Python 3.9 docker image for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.10.5-slim-bullseye as base-image
+FROM python:3.9.13-slim-bullseye as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .


### PR DESCRIPTION
Until we update kopf #48, we need to continue to use Python 3.9. This reverts the Docker base image change, and also limits dependabot to only patch updates to the Python docker image version (if I have the [configuration right](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)).