### PR TITLE
DM-35659: Initial implementation of integration tests with minikube

### DIFF
--- a/.github/workflows/minikube.yaml
+++ b/.github/workflows/minikube.yaml
@@ -1,0 +1,55 @@
+name: Minikube integration
+
+"on":
+  push:
+    branches:
+      - "tickets/**"
+  workflow_dispatch: {}
+
+jobs:
+
+  minikube:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install httpie
+        run: brew install httpie
+
+      - name: Set up Minikube
+        uses: medyagh/setup-minikube@v0.0.8
+        with:
+          minikube-version: "latest"
+          kubernetes-version: "v1.22.8"
+          driver: ""
+
+      - name: Test interaction with the cluster
+        run: kubectl get nodes
+
+      - name: Set up Kafka
+        shell: bash
+        working-directory: "minikube"
+        run: "./setupkafka.sh 0.29.0"
+
+      - name: Build image in Minikube
+        shell: bash
+        working-directory: "minikube"
+        run: "./buildimage.sh"
+
+      - name: Deploy strimzi-registry-operator
+        shell: bash
+        working-directory: "minikube"
+        run: "./deploysro.sh"
+
+      - name: Deploy a StrimziSchemaRegistry
+        shell: bash
+        working-directory: "minikube"
+        run: "./deployregistry.sh"
+
+      - name: Test Registry API
+        shell: bash
+        working-directory: "minikube"
+        run: "./testregistryapi.sh confluent-schema-registry"

--- a/manifests/registry-crd.yaml
+++ b/manifests/registry-crd.yaml
@@ -32,6 +32,13 @@ spec:
                   default: "tls"
                   description: >-
                     The name of the Kafka listener to use to connect.
+                serviceType:
+                  type: string
+                  default: "ClusterIP"
+                  description: >-
+                    The type of service to create for the registry. Default is
+                    ClusterIP. Can be NodePort to publish the registry
+                    externally.
   names:
     kind: StrimziSchemaRegistry
     plural: strimzischemaregistries

--- a/minikube/.gitignore
+++ b/minikube/.gitignore
@@ -1,0 +1,2 @@
+# strimzi distribution downloads
+strimzi-*/

--- a/minikube/buildimage.sh
+++ b/minikube/buildimage.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Build the strimzi-registry-operator docker image inside minikube
+# Based on https://minikube.sigs.k8s.io/docs/tutorials/setup_minikube_in_github_actions/
+eval $(minikube -p minikube docker-env)
+docker build -f ../Dockerfile -t local/strimzi-registry-operator ../
+echo -n "Verifying images:"
+docker images

--- a/minikube/deployregistry.sh
+++ b/minikube/deployregistry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Deploy a StrimziSchemaRegistry, along with the Kafka user and topics
+# required for it.
+#
+# Example:
+# ./deployregistry.sh
+
+# Deploy Kafka Topic for Schema Registry
+kubectl apply -f registry-topic.yaml -n default
+kubectl wait kafkatopic/registry-schemas --for=condition=Ready --timeout=300s
+
+# Deploy Kafka User for Schema Registry
+kubectl apply -f registry-user.yaml -n default
+kubectl wait kafkauser/confluent-schema-registry --for=condition=Ready --timeout=300s
+
+sleep 5s
+
+kubectl apply -f schema-registry.yaml
+sleep 10s # wait for registry-operator to create deployment
+kubectl wait -n default deployment confluent-schema-registry \
+    --for condition=Available=True --timeout=600s

--- a/minikube/deploysro.sh
+++ b/minikube/deploysro.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Deploy strimzi registry operator using kustomized configuration
+
+kustomize build operator-deployment | kubectl apply -f -
+kubectl wait -n default deployment strimzi-registry-operator \
+--for condition=Available=True --timeout=600s
+sleep 5s
+kubectl get crds
+kubectl get deployments

--- a/minikube/kafka.yaml
+++ b/minikube/kafka.yaml
@@ -1,0 +1,38 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: test-cluster
+spec:
+  kafka:
+    version: 3.2.0
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+        authentication:
+          type: tls
+      # TODO consider adding an external listener using a load balancer?
+    authorization:
+      type: simple
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.2"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/minikube/operator-deployment/kustomization.yaml
+++ b/minikube/operator-deployment/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  # adopt the docker image build locally inside minikube
+  - name: lsstsqre/strimzi-registry-operator
+    newName: local/strimzi-registry-operator
+    newTag: latest
+
+resources:
+  - ../../manifests/
+
+patches:
+  - sro-deployment.yaml

--- a/minikube/operator-deployment/sro-deployment.yaml
+++ b/minikube/operator-deployment/sro-deployment.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-registry-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: operator
+          imagePullPolicy: Never # for locally-built image
+          env:
+            - name: SSR_CLUSTER_NAME
+              value: test-cluster
+            - name: SSR_NAMESPACE
+              value: default

--- a/minikube/registry-topic.yaml
+++ b/minikube/registry-topic.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: registry-schemas
+  labels:
+    strimzi.io/cluster: test-cluster
+spec:
+  partitions: 1
+  replicas: 1 # because a single node Kafka cluster for testing
+  config:
+    # http://kafka.apache.org/documentation/#topicconfigs
+    cleanup.policy: compact

--- a/minikube/registry-user.yaml
+++ b/minikube/registry-user.yaml
@@ -1,0 +1,39 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: confluent-schema-registry
+  labels:
+    strimzi.io/cluster: test-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    # Official docs on authorizations required for the Schema Registry:
+    # https://docs.confluent.io/current/schema-registry/security/index.html#authorizing-access-to-the-schemas-topic
+    type: simple
+    acls:
+      # Allow all operations on the registry-schemas topic
+      # Note this replaces the _schemas topic normally used, but is
+      # hard to define with the Strimzi Topic Operator.
+      # Read, Write, and DescribeConfigs are known to be required
+      - resource:
+          type: topic
+          name: registry-schemas
+          patternType: literal
+        operation: All
+        type: allow
+      # Allow all operations on the schema-registry* group
+      - resource:
+          type: group
+          name: schema-registry
+          patternType: prefix
+        operation: All
+        type: allow
+      # Allow Describe on the __consumer_offsets topic
+      # (The official docs also mention DescribeConfigs?)
+      - resource:
+          type: topic
+          name: __consumer_offsets
+          patternType: literal
+        operation: Describe
+        type: allow

--- a/minikube/schema-registry.yaml
+++ b/minikube/schema-registry.yaml
@@ -1,0 +1,8 @@
+apiVersion: roundtable.lsst.codes/v1beta1
+kind: StrimziSchemaRegistry
+metadata:
+  name: confluent-schema-registry
+spec:
+  strimzi-version: v1beta2
+  listener: tls
+  serviceType: NodePort

--- a/minikube/setupkafka.sh
+++ b/minikube/setupkafka.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Deploy a Strimzi Kafka
+# testregistryapi.sh strimzi-version
+#
+# Positional argumennts:
+# - strimzi-version is the version of strimzi to use
+#
+# Example:
+# ./testregistryapi.sh 0.29.0
+
+# Download Strimzi release with Kubernetes manifests
+curl -L0 https://github.com/strimzi/strimzi-kafka-operator/releases/download/$1/strimzi-$1.tar.gz | tar xvz
+
+# Configure Strimzi to watch a single namespace
+# https://strimzi.io/docs/operators/latest/deploying.html#deploying-cluster-operator-str
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS version of sed command
+    sed -i '' 's/namespace: .*/namespace: default/' \
+        strimzi-$1/install/cluster-operator/*RoleBinding*.yaml
+else
+    # General linux version of sed command
+    sed -i 's/namespace: .*/namespace: default/' \
+        strimzi-$1/install/cluster-operator/*RoleBinding*.yaml
+fi
+
+# Deploy Strimzi Cluster Operator
+kubectl apply -f strimzi-$1/install/cluster-operator -n default
+kubectl wait -n default deployment strimzi-cluster-operator --for condition=Available=True --timeout=600s
+
+# Deploy a Kafka cluster
+kubectl apply -f kafka.yaml -n default
+kubectl wait kafka/test-cluster --for=condition=Ready --timeout=300s

--- a/minikube/testregistryapi.sh
+++ b/minikube/testregistryapi.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Simple exercise of the Schema Registry's API to demonstrate functionality
+# testregistryapi.sh registry-name
+#
+# Positional argumennts:
+# - registry-name is the name of the StrimziSchemaRegistry to connect to
+#
+# Example:
+# ./testregistryapi.sh confluent-schema-registry
+
+# Create a connection to the NodePort service in Minikube
+minikube service list
+minikube service $1 --url
+echo "------------------opening the service------------------"
+echo $(minikube service $1 --url)
+# Pause for service to stablilize
+sleep 30s
+
+# Get URL for registry service
+export REGISTRY_URL=$(minikube service $1 --url)
+echo $REGISTRY_URL
+sleep 1s
+
+# Test call to the registry's /config endpoint
+http --ignore-stdin get $REGISTRY_URL/config
+sleep 1s
+
+# Post a new schema to the registry
+http --ignore-stdin --json post $REGISTRY_URL/subjects/testsubject/versions \
+    schema=@testsubject.json \
+    Accept:application/vnd.schemaregistry.v1+json
+sleep 1s
+
+# Get schema back
+http --ignore-stdin --json get $REGISTRY_URL/subjects/testsubject/versions/1 \
+    Accept:application/vnd.schemaregistry.v1+json

--- a/minikube/testsubject.json
+++ b/minikube/testsubject.json
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "testsubject",
+  "fields": [
+    {"name": "field1", "type": "int"},
+    {"name": "field2", "type": "string"}
+  ]
+}

--- a/strimziregistryoperator/deployments.py
+++ b/strimziregistryoperator/deployments.py
@@ -2,7 +2,7 @@
 
 __all__ = ["get_kafka_bootstrap_server", "create_deployment", "create_service"]
 
-from typing import Mapping
+from typing import Any, Dict, Mapping
 
 import kopf
 
@@ -265,7 +265,9 @@ def create_container_spec(*, secret_name, bootstrap_server):
     return registry_container
 
 
-def create_service(*, name):
+def create_service(
+    *, name: str, service_type: str = "ClusterIp"
+) -> Dict[str, Any]:
     """Create a Service resource for the Schema Registry.
 
     Parameters
@@ -273,6 +275,9 @@ def create_service(*, name):
     name : `str`
         Name of the StrimziKafkaUser, which is also used as the name of the
         deployment.
+    service_type : `str`
+        The Kubernetes service type. Typically ClusterIP, but could be
+        NodePort for testing with Minikube.
 
     Returns
     -------
@@ -284,6 +289,7 @@ def create_service(*, name):
         "kind": "Service",
         "metadata": {"name": name, "labels": {"name": name}},
         "spec": {
+            "type": service_type,
             "ports": [{"name": "schema-registry", "port": 8081}],
             "selector": {
                 "app": name,

--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -64,12 +64,15 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
             listener_name,
         )
 
+    service_type = spec.get("serviceType", "ClusterIP")
+
     logger.info(
         "Creating a new Schema Registry deployment: %s with listener=%s and "
-        "strimzi-version=%s",
+        "strimzi-version=%s serviceType=%s",
         name,
         listener_name,
         strimzi_api_version,
+        service_type,
     )
 
     # Get the name of the Kafka cluster associated with the
@@ -148,7 +151,7 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
 
     # Create the http service to access the Schema Registry REST API
     if not service_exists:
-        svc_body = create_service(name=name)
+        svc_body = create_service(name=name, service_type=service_type)
         # Set the StrimziSchemaRegistry as the owner
         kopf.adopt(svc_body, owner=body)
         svc_response = k8s_core_v1_api.create_namespaced_service(

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -4,7 +4,10 @@ import kopf
 import pytest
 import yaml
 
-from strimziregistryoperator.deployments import get_kafka_bootstrap_server
+from strimziregistryoperator.deployments import (
+    create_service,
+    get_kafka_bootstrap_server,
+)
 
 
 def test_get_cluster_listener_strimzi_v1beta1():
@@ -146,3 +149,19 @@ status:
 
     server = get_kafka_bootstrap_server(kafka, listener_name="tls")
     assert server == "sasquatch-kafka-bootstrap.sasquatch.svc:9093"
+
+
+def test_create_clusterip_service() -> None:
+    """Create a ClusterIP service resource spec for the Schema Registry."""
+    resource = create_service(
+        name="confluent-schema-registry", service_type="ClusterIP"
+    )
+    assert resource["spec"]["type"] == "ClusterIP"
+
+
+def test_create_nodeport_service() -> None:
+    """Create a NodePort service resource spec for the Schema Registry."""
+    resource = create_service(
+        name="confluent-schema-registry", service_type="NodePort"
+    )
+    assert resource["spec"]["type"] == "NodePort"


### PR DESCRIPTION
This is a demonstration of running Strimzi Kafka in minikube to perform integration tests on strimzi-registry-operator. This should rebased and merged _after_ #53 (it currently includes that code).

All the Kubernetes resources and deployment scripts are located in
minikube/

- The `setupkafka.sh` script deploys a Kafka cluster with Strimzi inside minikube.
- The `buildimage.sh` script is responsible for building the strimzi registry operator image *locally* within the minikube environment, so that the branch can be tested without pulling from a container registry. This uses minikube's docker-env feature.
- The `deploysro.sh` script runs a deployment of the strimzi schema registry operator using kustomization directory, operator-deployment/ This kustomization essentially changes the operator's deployment to pull from the local image in minikube.
- The `deployregistry.sh` script deployed the schema registry resource along with the strimzi KafkaUser and KafkaTopic resources required to run a registry.
- The `testregistry.sh` script tests the schema registry by exercising its API.
