### PR TITLE
Fix compatibilityLevel setting

### DIFF
--- a/strimziregistryoperator/handlers/createregistry.py
+++ b/strimziregistryoperator/handlers/createregistry.py
@@ -91,7 +91,7 @@ def create_registry(spec, meta, namespace, name, uid, logger, body, **kwargs):
     registry_mem_request = get_nullable(spec, "memoryRequest")
 
     # Additional schema Registry configurations
-    registry_compatibility_level = spec.get("compatibilitylevel", "forward")
+    registry_compatibility_level = spec.get("compatibilityLevel", "forward")
     security_protocol = spec.get("securityProtocol", "SSL")
 
     logger.info(


### PR DESCRIPTION
It is always set to forward compatibility, as the StrimziSchemaRegistry custom resource field for compatibility is compatibilityLevel. However, in the code, it is written in all lowercase as compatibilitylevel