### PR TITLE
publish linux/amd64 images as well

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
         id: build
         with:
           image: ${{ github.repository }}
+          platforms: linux/amd64,linux/arm64
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report result


### PR DESCRIPTION
Hello! Thank you for the operator, it seems like [`platforms: [...]`](https://github.com/lsst-sqre/build-and-push-to-ghcr/blob/e2feb8313090afea07f0d9cbdeed07350d2e191e/action.yaml#L24C1-L26) is all that's required to get cross-platform images published, it'd be very much appreciated if that's the case